### PR TITLE
fix migration scripts to reference contract names rather than file names

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,4 +1,4 @@
-var Migrations = artifacts.require("./Migrations.sol");
+var Migrations = artifacts.require("Migrations");
 
 module.exports = function(deployer) {
   deployer.deploy(Migrations);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,6 +1,6 @@
-var SimpleStorage = artifacts.require("./SimpleStorage.sol");
-var TutorialToken = artifacts.require("./TutorialToken.sol");
-var ComplexStorage = artifacts.require("./ComplexStorage.sol");
+var SimpleStorage = artifacts.require("SimpleStorage");
+var TutorialToken = artifacts.require("TutorialToken");
+var ComplexStorage = artifacts.require("ComplexStorage");
 
 module.exports = function(deployer) {
   deployer.deploy(SimpleStorage);


### PR DESCRIPTION
This change follows the recommendations in the Truffle Suite [documentation](http://truffleframework.com/docs/getting_started/migrations). I've tested this code and it works as expected!