### PR TITLE
update dependencies to resolve issues #18 and #29

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "zeppelin-solidity": "^1.6.0"
   },
   "dependencies": {
+    "eth-block-tracker-es5": "^2.3.2",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
@@ -60,7 +61,8 @@
     "redux": "^3.6.0",
     "redux-auth-wrapper": "^1.0.0",
     "redux-saga": "^0.15.3",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "web3": "1.0.0-beta.34"
   },
   "scripts": {
     "start": "node scripts/start.js",


### PR DESCRIPTION
Solution discovered by @ColdDevil and found to work by a number of developers, including myself, who got errors when starting a fresh Drizzle Box using the latest version.

See: https://github.com/truffle-box/drizzle-box/issues/18#issuecomment-384364096
More discussion: https://github.com/truffle-box/drizzle-box/issues/29