### PR TITLE
update openzeppelin-solidity dependency to ^1.9.0

### DIFF
--- a/contracts/TutorialToken.sol
+++ b/contracts/TutorialToken.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.23;
 
-import "zeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 
 contract TutorialToken is StandardToken {
   string public name = "TutorialToken";
@@ -8,7 +8,7 @@ contract TutorialToken is StandardToken {
   uint public decimals = 2;
   uint public INITIAL_SUPPLY = 12000;
 
-  function TutorialToken() public {
+  constructor() public {
     totalSupply_ = INITIAL_SUPPLY;
     balances[msg.sender] = INITIAL_SUPPLY;
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "17.0.2",
     "json-loader": "0.5.4",
     "object-assign": "4.1.0",
+    "openzeppelin-solidity": "^1.9.0",
     "path-exists": "2.1.0",
     "postcss-loader": "1.0.0",
     "promise": "7.1.1",
@@ -48,8 +49,7 @@
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
-    "whatwg-fetch": "1.0.0",
-    "zeppelin-solidity": "^1.6.0"
+    "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
     "eth-block-tracker-es5": "^2.3.2",


### PR DESCRIPTION
Release notes: https://github.com/OpenZeppelin/openzeppelin-solidity/releases/tag/v1.9.0

The package name changed to openzeppelin-solidity for this release.

I've also updated the TutorialToken contract, which uses the OpenZeppelin library.