### PR TITLE
added support for IGNORE_DRIZZLE_BOX_WARNINGS flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ This box comes with everything you need to start using smart contracts from a re
 
     This box is a marriage of [Truffle](http://truffleframework.com/) and a React setup created with [create-react-app](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md). Either one would be a great place to start!
 
-* __I'm trying to run `truffle unbox drizzle` in my CI environment but my build keeps failing. How can I fix it?
+* __I'm trying to run `truffle unbox drizzle` in my CI environment but my build keeps failing. How can I fix it?__
 
    We're treating warnings as errors when the env variable `CI` is set to `true`. If this is affecting your ability to unbox drizzle in your CI environment, you can set the variable `IGNORE_DRIZZLE_BOX_WARNINGS=true` and warnings won't be treated as errors anymore during unboxing.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ This box comes with everything you need to start using smart contracts from a re
 * __Where can I find more documentation?__
 
     This box is a marriage of [Truffle](http://truffleframework.com/) and a React setup created with [create-react-app](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md). Either one would be a great place to start!
+
+* __I'm trying to run `truffle unbox drizzle` in my CI environment but my build keeps failing. How can I fix it?
+
+   We're treating warnings as errors when the env variable `CI` is set to `true`. If this is affecting your ability to unbox drizzle in your CI environment, you can set the variable `IGNORE_DRIZZLE_BOX_WARNINGS=true` and warnings won't be treated as errors anymore during unboxing.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -120,10 +120,10 @@ function build(previousFileSizes) {
         return reject(new Error(messages.errors.join('\n\n')));
       }
       if (
-        process.env.CI &&
-        (typeof process.env.CI !== 'string' ||
-          process.env.CI.toLowerCase() !== 'false') &&
-        messages.warnings.length
+          !process.env.IGNORE_DRIZZLE_BOX_WARNINGS && (
+            process.env.CI && (typeof process.env.CI !== 'string' ||
+            process.env.CI.toLowerCase() !== 'false') && messages.warnings.length
+          )
       ) {
         console.log(
           chalk.yellow(


### PR DESCRIPTION
@adrianmcli As discussed previously,  this new flag allows you to ignore the rule "Treat warnings as errors on CI" (See https://github.com/truffle-box/drizzle-box/blob/master/scripts/build.js#L130), so external users like MetaMask can still unbox it on CI without caring about the warnings that happen during unboxing.

(I've tried to update the deps with vuln, but there are 4 in total and some of those are deps of deps so it's not a very easy task)