### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",
-    "web3": "^1.0.0-beta.34",
+    "web3": "1.0.0-beta.34",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",
     "webpack-manifest-plugin": "1.3.2",


### PR DESCRIPTION
Web3 version - ^1.0.0-beta.34 (1.0.0-beta.35 and above) are 
incompatible and gives following error

Error Message - 

"Module not found: Error: Can't resolve 'websocket' in '/Users/harshpatel/codebase/git/Archive/test/test_Drizzle/drizzle-box/node_modules/drizzle/node_modules/web3-providers-ws/src'" 

Hence downgrading to 1.0.0-beta.34 to meet the operational needs. 