### PR TITLE
Add .gitattributes to add Solidity syntax highlighting on Github.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
I learned about this from [Open Zeppelin's repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes). You can see the [working example](https://github.com/EarthEngineering/drizzle-box/blob/master/contracts/ComplexStorage.sol) in the repo which this PR is from.